### PR TITLE
Fix duplicate content on start page

### DIFF
--- a/site2pdf.py
+++ b/site2pdf.py
@@ -206,7 +206,9 @@ def main():
                 if new_styles:
                     tag['style'] = '; '.join(new_styles)
                     if tag['style'] != original_style:
-                        logging.debug(f'Updated style from "{original_style}" to "{tag['style']}" in tag {tag}')
+                        logging.debug(
+                            f"Updated style from '{original_style}' to '{tag['style']}' in tag {tag}"
+                        )
                 else:
                     del tag['style']
 
@@ -217,6 +219,9 @@ def main():
     except Exception as e:
         logging.error(f'Failed to fetch start URL {args.url}: {e}')
         exit(1)
+
+    # Mark the start URL as visited to avoid reprocessing it
+    visited_urls.add(args.url)
 
     # Determine which processing method to use
     if args.next_page_class:


### PR DESCRIPTION
## Summary
- mark start page as visited to avoid reprocessing it when linked from index pages

## Testing
- `python -m py_compile site2pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_687a2acde8188320a178dea06d1557f9