### PR TITLE
Fix README license

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ pip install requests beautifulsoup4 xhtml2pdf
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
 
 ## Author
 


### PR DESCRIPTION
## Summary
- update README to state Apache License 2.0

## Testing
- `python -m py_compile site2pdf.py`

------
https://chatgpt.com/codex/tasks/task_e_687a2f2888c48320be2e1036ffa8e427